### PR TITLE
Atualiza diretória que será marcada no boletim mensal

### DIFF
--- a/.github/workflows/boletim.yaml
+++ b/.github/workflows/boletim.yaml
@@ -44,9 +44,9 @@ jobs:
 
           # Define atribuição
           assignees[0]="tiidadavena"
-          assignees[1]="muriloviana"
-          assignees[2]="rougeth"
-          assignees[3]="anadulce"
+          assignees[1]="cecivieira"
+          assignees[2]="naanadr"
+          assignees[3]="anicelysantos"
 
           month=$(date +%m)
           size=${#assignees[@]}


### PR DESCRIPTION
Remove diretória antiga (2023-2024) da APyB e adiciona a diretória atual (2024-2025) na lista de usuários para serem marcados no boletim mensal.

Closes https://github.com/apyb/tarefas/issues/522