### PR TITLE
Adiciona workflow para criação de commit vazio mensal

### DIFF
--- a/.github/workflows/commit-vazio.yaml
+++ b/.github/workflows/commit-vazio.yaml
@@ -1,0 +1,28 @@
+name: Commit vazio para manter o repositório ativo
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 1 * *
+
+env:
+  LANG: "pt_BR.UTF-8"
+
+jobs:
+  empty_commit:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - run: git config user.email ${{ secrets.BOT_EMAIL }}
+    - run: git config user.name "apyb-bot"
+
+    - name: Cria commit vazio
+      run: git commit --allow-empty -m "Commit mensal para manter o repositório ativo""
+
+    - name: Push commit
+      run: git push origin main
+      env:
+        GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/commit-vazio.yaml
+++ b/.github/workflows/commit-vazio.yaml
@@ -18,11 +18,14 @@ jobs:
 
     - run: git config user.email ${{ secrets.BOT_EMAIL }}
     - run: git config user.name "apyb-bot"
+    
+    - name: Altera branch
+      run: git checkout repo/commits-vazios
 
     - name: Cria commit vazio
       run: git commit --allow-empty -m "Commit mensal para manter o repositório ativo""
 
     - name: Push commit
-      run: git push origin main
+      run: git push origin repo/commits-vazios
       env:
         GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/commit-vazio.yaml
+++ b/.github/workflows/commit-vazio.yaml
@@ -1,4 +1,4 @@
-name: Commit vazio para manter o repositório ativo
+name: Commit Vazio Mensal
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Commit tem o objetivo de manter o repositório ativo, visto que se um repositório público não tiver um novo commit em menos de 60 dias o GitHub desativa os Workflows agendados.

```
In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days.
```

[Fonte](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow)

Closes https://github.com/apyb/tarefas/issues/536